### PR TITLE
Fix small typo (it's -> its) in the core-js article

### DIFF
--- a/content/posts/2023/03-12-revisiting-core-js.md
+++ b/content/posts/2023/03-12-revisiting-core-js.md
@@ -183,7 +183,7 @@ situation.
 
 But this is a sort of _“Tale of Two Cities”_ - despite the clear and present
 danger the project was in and regardless of veiled threats leveraged against
-the community by it’s sole maintainer, JavaScript developers disregarded this
+the community by its sole maintainer, JavaScript developers disregarded this
 risk, big businesses consumed it as a deeply integrated dependency,
 and everyone increased their usage of the library, ignoring a potentially
 worsening situation.


### PR DESCRIPTION
Thanks for the nice article BTW 😉